### PR TITLE
Check for a display before switching with open source drivers

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -287,7 +287,7 @@ switch() {
 		fi
 	fi
 
-    if [ $1 = "egpu" ] && [ -z $(grep -e "nvidia" $XFILE_EGPU) ]; then
+    if [ $1 = "egpu" ] && [ $(grep -ce "nvidia" $XFILE_EGPU) -eq 0 ]; then
         EGPU_PCI_ID=$(cat $XFILE_EGPU | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
 		# create an array by splitting the BUS-ID on ':'
 		busArray=(${EGPU_PCI_ID//:/ })
@@ -300,8 +300,8 @@ switch() {
 		bus3h=$(printf "%01x" $bus3d)
 		HEX_ID=$(echo $bus1h:$bus2h.$bus3h)
     	DISPLAY_ON="false"
-    	for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/enabled); do
-      		if [ ${DISP} = "enabled" ]; then
+    	for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
+      		if [ ${DISP} = "connected" ]; then
         		DISPLAY_ON="true"
       		fi
     	done

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -287,8 +287,8 @@ switch() {
 		fi
 	fi
 
-    if [ $1 = "egpu" ] && [ $(grep -ce "nvidia" $XFILE_EGPU) -eq 0 ]; then
-        EGPU_PCI_ID=$(cat $XFILE_EGPU | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
+	if [ $1 = "egpu" ] && [ $(grep -ce "nvidia" $XFILE_EGPU) -eq 0 ]; then
+		EGPU_PCI_ID=$(cat $XFILE_EGPU | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
 		# create an array by splitting the BUS-ID on ':'
 		busArray=(${EGPU_PCI_ID//:/ })
 		bus1d=${busArray[0]}
@@ -299,19 +299,25 @@ switch() {
 		bus2h=$(printf "%02x" $bus2d)
 		bus3h=$(printf "%01x" $bus3d)
 		HEX_ID=$(echo $bus1h:$bus2h.$bus3h)
-    	DISPLAY_ON="false"
-    	for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
-      		if [ ${DISP} = "connected" ]; then
-        		DISPLAY_ON="true"
-      		fi
-    	done
-    	if [ ${DISPLAY_ON} = "false" ]; then
-      		echo "Warning: No eGPU attached display detected with open source drivers"
-      		echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration"
-      		echo "Not setting eGPU mode."
-            set -- "internal"
+		DISP_PATH=/sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status
+		DISP_NUM=$(ls ${DISP_PATH} | grep -c status)
+    	# for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
+     #  		if [ ${DISP} = "connected" ]; then
+     #    		DISPLAY_ON="true"
+     #  		fi
+    	# done
+		if [ $(cat ${DISP_PATH} | grep -ce ^disconnected$) -eq $DISP_NUM ] && [ $DISP_NUM -gt 0 ]; then
+			echo -e "$WARN No eGPU attached display detected with open source drivers. Internal mode and setting DRI_PRIME variable are recommended for this configuration."
+			if [[ $2 = "override" ]]; then
+				echo -e "$WARN -> Overridden: Setting eGPU mode"
+				set -- "egpu"
+			else
+				echo -e "$WARN Run 'egpu-switcher switch egpu override' to force loading eGPU mode"
+				echo -e "$WARN -> Not setting eGPU mode."
+				set -- "internal"
+			fi
 		fi
-    fi
+	fi
 
 	if [ $1 = "egpu" ]; then
 		echo -e "$INFO Create symlink $GREEN$XFILE$BLANK -> $XFILE_EGPU"

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -287,6 +287,32 @@ switch() {
 		fi
 	fi
 
+    if [ $1 = "egpu" ] && [ -z $(grep -e "nvidia" $XFILE_EGPU) ]; then
+        EGPU_PCI_ID=$(cat $XFILE_EGPU | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
+		# create an array by splitting the BUS-ID on ':'
+		busArray=(${EGPU_PCI_ID//:/ })
+		bus1d=${busArray[0]}
+		bus2d=${busArray[1]}
+		bus3d=${busArray[2]}
+		# convert dec to hex
+		bus1h=$(printf "%02x" $bus1d)
+		bus2h=$(printf "%02x" $bus2d)
+		bus3h=$(printf "%01x" $bus3d)
+		HEX_ID=$(echo $bus1h:$bus2h.$bus3h)
+    	DISPLAY_ON="false"
+    	for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/enabled); do
+      		if [ ${DISP} = "enabled" ]; then
+        		DISPLAY_ON="true"
+      		fi
+    	done
+    	if [ ${DISPLAY_ON} = "false" ]; then
+      		echo "Warning: No eGPU attached display detected with open source drivers"
+      		echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration"
+      		echo "Not setting eGPU mode."
+            set -- "internal"
+		fi
+    fi
+
 	if [ $1 = "egpu" ]; then
 		echo -e "$INFO Create symlink $GREEN$XFILE$BLANK -> $XFILE_EGPU"
 		ln -sf $XFILE_EGPU $XFILE

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -301,11 +301,6 @@ switch() {
 		HEX_ID=$(echo $bus1h:$bus2h.$bus3h)
 		DISP_PATH=/sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status
 		DISP_NUM=$(ls ${DISP_PATH} | grep -c status)
-    	# for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
-     #  		if [ ${DISP} = "connected" ]; then
-     #    		DISPLAY_ON="true"
-     #  		fi
-    	# done
 		if [ $(cat ${DISP_PATH} | grep -ce ^disconnected$) -eq $DISP_NUM ] && [ $DISP_NUM -gt 0 ]; then
 			echo -e "$WARN No eGPU attached display detected with open source drivers. Internal mode and setting DRI_PRIME variable are recommended for this configuration."
 			if [[ $2 = "override" ]]; then


### PR DESCRIPTION
Currently, the eGPU mode works well for all cards when a display is connected to the eGPU and also works when looping back to the internal display on nvidia cards with proprietary drivers and nvidia-prime. For amd cards or nvidia cards using the nouveau driver, trying to use the eGPU mode with the internal display only causes lagging or black screens. These changes check for non-nvidia drivers, then check the display outputs of the eGPU to see if any are connected. If not, it stops loading of the eGPU mode and prompts the user to use the DRI_PRIME environment variable.

I'm not sure if the user prompt is the best method, but I figured it would be the easiest to deal with. I tested with both amd and nvidia cards but only using an HDMI display. Checking the displayport/DVI behavior might be a good idea.