### PR TITLE
read_gpus(): use lspci's "-d" switch to detect 3D and VGA contollers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/hertg/egpu-switcher
 
 Package: egpu-switcher
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: pciutils (>= 3.3.0), ${shlibs:Depends}, ${misc:Depends}
 Description: Utility to detect and switch GPUs
  This tool allows the user to automatically detect the connected
  (external) GPUs. After selecting which GPU should be used as internal

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -101,7 +101,7 @@ function read_gpus() {
 	# empty the gpus array
 	gpus=()
 
-	declare lines=$(lspci | grep -i -E "^[^\s]+\s+.*(vga|3d)")
+	declare lines=$(lspci -d ::0300 && lspci -d ::0302)
 	while read -r line ; do
 		declare name=$(echo $line | grep -o -e "[^:]*$")
 		declare bus=$(echo $line | grep -o -e "^[^ ]*")


### PR DESCRIPTION
From pciutils 3.3.0 Changelog:
```
	* Filters now support matching by device class. Original
	  patch by Matthew Wilcox, wrappers for ABI compatibility
	  by me.
```

* Debian Jessie (8, currently "oldoldstable") wouldn't be compatible with this change as it uses `3.2.1`.
* Debian Stretch (9, currently "oldstable") and up are compatible, as Debian Stretch uses `3.5.2`
* Ubuntu Xenial (16.04LTS) and up are compatible, as Ubuntu Xenial uses `3.3.1`

Closes #22