### PR TITLE
Add eGPU "remove" function

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -404,6 +404,59 @@ function switch() {
 	print_error "The argument '${mode}' that was passed to the switch() method is not valid."
 }
 
+function remove() {
+	# Might want to make this block a function to return hex id, used 3 times in script now
+	declare egpu_pci_id=$(cat $xfile_egpu | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
+	declare busArray=(${egpu_pci_id//:/ })
+	declare bus1d=${busArray[0]}
+	declare bus2d=${busArray[1]}
+	declare bus3d=${busArray[2]}
+	declare bus1h=$(printf "%02x" $bus1d)
+	declare bus2h=$(printf "%02x" $bus2d)
+	declare bus3h=$(printf "%01x" $bus3d)
+	declare hex_id=$(echo $bus1h:$bus2h.$bus3h)
+
+	# Find GPU and audio devices
+	declare device_id=$(echo ${hex_id} | cut -f 1 -d '.').
+	declare device_path=/sys/bus/pci/devices/[0-9a-f:]*${device_id}[0-9]*/remove
+
+	# Find drivers from lspci
+	if [ $(lspci -k | grep -A 3 ${hex_id} | grep -c "nvidia") -gt 0 ]; then
+		declare vga_driver=nvidia
+	elif [ $(lspci -k | grep -A 3 ${hex_id} | grep -c "amdgpu") -gt 0 ]; then
+		declare vga_driver=amdgpu
+	else
+		print_error "Neither Nvidia or AMD GPU found at Bus ID specified in xorg.conf.egpu"
+		exit
+	fi
+
+	# Do actual GPU removal
+	( trap '' HUP TERM
+		while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
+			= "active" ]; do
+			sleep 1
+		done
+
+		if [ ${vga_driver} = "nvidia" ]; then
+			for drivers in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
+				modprobe -r ${drivers}
+			done
+		else
+			modprobe -r ${vga_driver}
+		fi
+
+		for dev_paths in ${device_path}; do
+			if [ -e $dev_paths ]; then
+				echo 1 > $dev_paths
+			fi
+		done
+
+		modprobe ${vga_driver}
+
+		systemctl start display-manager.service ) &
+	systemctl stop display-manager.service
+}
+
 function cleanup() {
 
 	declare hard=${1}
@@ -493,9 +546,17 @@ elif [ $1 = "cleanup" ]; then
 
 	cleanup ${hard}
 
+elif [ $1 = "remove" ]; then
+
+	print_warn "This will switch to internal mode, remove the eGPU and log out all users. Continue? [y/N]: "
+	read specify_remove
+	if [[ $specify_remove == "y" ]]; then
+		switch internal 0
+		remove
+	fi
 
 else
-	print_error "Unknown argument '$1'.\navailable commands: setup, switch, config, cleanup"
+	print_error "Unknown argument '$1'.\navailable commands: setup, switch, config, cleanup, remove"
 fi
 
 # systemctl restart display-manager.service

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -422,10 +422,20 @@ function remove() {
 
 		if [ ${vga_driver} = "nvidia" ]; then
 			systemctl stop nvidia-persistenced.service
+			if [ $(lsmod | grep "nvidia_uvm " | awk '{print $3}') -gt 0 ] || [ $(lsmod | grep "nvidia_drm " | awk '{print $3}') -gt 0 ]; then
+				systemctl start display-manager.service
+				print_error "Driver still in use. Check for applications like Folding@Home running in the background. Stopping removal."
+				exit
+			fi
 			for drivers in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
 				modprobe -r ${drivers}
 			done
 		else
+			if [ $(lsmod | grep "${vga_driver} " | awk '{print $3}') -gt 0 ]; then
+				systemctl start display-manager.service
+				print_error "Driver still in use. Check for applications like Folding@Home running in the background. Stopping removal."
+				exit
+			fi
 			modprobe -r ${vga_driver}
 		fi
 
@@ -437,6 +447,10 @@ function remove() {
 
 		if [ $(lspci -k | grep -c ${vga_driver}) -gt 0 ]; then
 			modprobe ${vga_driver}
+			if [ ${vga_driver} = "nvidia" ]; then
+				modprobe nvidia_drm
+			fi
+			sleep 1
 		fi
 
 		systemctl start display-manager.service ) &

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -150,6 +150,7 @@ function is_egpu_connected() {
 	if [ $(lspci | grep -iEc "$bus1h:$bus2h.$bus3h") -eq 1 ]; then
 		print_info "EGPU is ${green}connected${blank}."
 		gpu_connected=1
+		hex_id=$bus1h:$bus2h.$bus3h
 		#return 1
 	else
 		print_info "EGPU is ${red}disconnected${blank}."
@@ -352,20 +353,12 @@ function switch() {
 		fi
 	fi
 
-	if [ ${mode} = "egpu" ] && [ $(grep -ce "nvidia" $xfile_egpu) -eq 0 ]; then
-		declare egpu_pci_id=$(cat $xfile_egpu | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
-		# create an array by splitting the BUS-ID on ':'
-		declare busArray=(${egpu_pci_id//:/ })
-		declare bus1d=${busArray[0]}
-		declare bus2d=${busArray[1]}
-		declare bus3d=${busArray[2]}
+	if [ ${mode} = "egpu" ] && [ $(cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \") != "nvidia" ]; then
 
-		# convert dec to hex
-		declare bus1h=$(printf "%02x" $bus1d)
-		declare bus2h=$(printf "%02x" $bus2d)
-		declare bus3h=$(printf "%01x" $bus3d)
+		if [ -z ${hex_id+x} ]; then
+			is_egpu_connected
+		fi
 		
-		declare hex_id=$(echo $bus1h:$bus2h.$bus3h)
 		declare disp_path=/sys/bus/pci/devices/[0-9a-f:]*${hex_id}/drm/card[0-9]*/card[0-9]*-*/status
 		declare disp_num=0
 		declare disp_disconnect=0
@@ -405,30 +398,20 @@ function switch() {
 }
 
 function remove() {
-	# Might want to make this block a function to return hex id, used 3 times in script now
-	declare egpu_pci_id=$(cat $xfile_egpu | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
-	declare busArray=(${egpu_pci_id//:/ })
-	declare bus1d=${busArray[0]}
-	declare bus2d=${busArray[1]}
-	declare bus3d=${busArray[2]}
-	declare bus1h=$(printf "%02x" $bus1d)
-	declare bus2h=$(printf "%02x" $bus2d)
-	declare bus3h=$(printf "%01x" $bus3d)
-	declare hex_id=$(echo $bus1h:$bus2h.$bus3h)
+
+	if [ -z ${hex_id+x} ]; then
+		is_egpu_connected
+	fi
+
+	if [ $gpu_connected = 0 ]; then
+		print_error "No eGPU detected at BusID specified in xorg.conf.egpu. Stopping removal."
+		exit
+	fi
 
 	# Find GPU and audio devices
 	declare device_id=$(echo ${hex_id} | cut -f 1 -d '.').
 	declare device_path=/sys/bus/pci/devices/[0-9a-f:]*${device_id}[0-9]*/remove
-
-	# Find drivers from lspci
-	if [ $(lspci -k | grep -A 3 ${hex_id} | grep -c "nvidia") -gt 0 ]; then
-		declare vga_driver=nvidia
-	elif [ $(lspci -k | grep -A 3 ${hex_id} | grep -c "amdgpu") -gt 0 ]; then
-		declare vga_driver=amdgpu
-	else
-		print_error "Neither Nvidia or AMD GPU found at Bus ID specified in xorg.conf.egpu"
-		exit
-	fi
+	declare vga_driver=$(cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \")
 
 	# Do actual GPU removal
 	( trap '' HUP TERM
@@ -548,7 +531,7 @@ elif [ $1 = "cleanup" ]; then
 
 elif [ $1 = "remove" ]; then
 
-	print_warn "This will switch to internal mode, remove the eGPU and log out all users. Continue? [y/N]: "
+	print_warn "This will switch to internal mode, remove the eGPU PCIe addresses and log out all users. Continue? [y/N]: "
 	read specify_remove
 	if [[ $specify_remove == "y" ]]; then
 		switch internal 0

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -434,7 +434,9 @@ function remove() {
 			fi
 		done
 
-		modprobe ${vga_driver}
+		if [ $(lspci -k | grep -c ${vga_driver}) -gt 0 ]; then
+			modprobe ${vga_driver}
+		fi
 
 		systemctl start display-manager.service ) &
 	systemctl stop display-manager.service

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -421,6 +421,7 @@ function remove() {
 		done
 
 		if [ ${vga_driver} = "nvidia" ]; then
+			systemctl stop nvidia-persistenced.service
 			for drivers in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
 				modprobe -r ${drivers}
 			done


### PR DESCRIPTION
This adds another function to the script called "remove" which stops the display manager, unloads the driver, removes the PCIe addresses of the eGPU, reloads the driver if necessary, then restarts the display manager. This is purely an enhancement. In my experience, this allows physically unplugging the eGPU anytime after the "remove" process completes. Without this, I would experience a system hang if the eGPU were unplugged. Let me know your experience with unplugging the eGPU, if this works for you or not, or if you have another way.

Note that AMD card users will see the following error message:
`[drm:amdgpu_pci_remove [amdgpu]] *ERROR* Device removal is currently not supported outside of fbcon`
Of the dozens of removals I've tried, I only had one error that required a hard reboot to solve. It seems like [patches](https://lists.freedesktop.org/archives/dri-devel/2020-May/265386.html) are in the works for better AMD removal (that might not even need restarting X). As it stands with the current kernels, all the steps I've added are strictly necessary for unplugging and they should remain the "safe" option even if better unplugging support comes later.

Also speaking of the kernel, I tried with a couple of old mainline kernels and found 5.0+ to be the requirement. Earlier ones did not work, but later worked fine on both the Linux Mint and Ubuntu systems I tested. Again, let me know what you think of this. I'd like to see it tested with more laptop configurations especially dGPU+eGPU. As it is I would consider this to be a "beta" feature that the user can call only if they want.

Finally, this also cleans up a little bit of code from my previous PR by allowing it to read the hex ID from the is_egpu_connected function.