### PR TITLE
Limit Race Condition / Add TROUBLESHOOT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,8 @@ $ make uninstall
 
 ---
 
-## Hints
-
-1. **Ubuntu 19.04 or later**\
-When installing Ubuntu 19.04 or later, please check the box "Install third-party software for graphics and Wi-Fi hardware". After that, all required drivers will be installed automatically.
-
-1. **Notebooks with hybrid graphics**\
-I am using a Lenovo notebook with hybrid graphics (internal graphics **and** a dedicated GPU). I've experienced freezes in the Ubuntu 19.04 installer which could only be resolved by changing the display settings in the BIOS from **Hybrid Graphics** to **Discrete Graphics**. After the installation was complete, i was able to change this setting back to **Hybrid Graphics**, without any issues.
+## Troubleshooting
+If you run into problems, please have a look at [TROUBLESHOOT.md](https://github.com/hertg/egpu-switcher/blob/master/TROUBLESHOOT.md) before reporting any issues.
 
 ## Background information
 > A backup of your current `xorg.conf` will be created, nothing gets deleted. If the script doesn't work for you, you can revert the changes by executing `egpu-switcher cleanup` or just completely uninstall the script with `apt remove egpu-switcher`. This will remove all files it has created and also restore your previous `xorg.conf` file.

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -1,0 +1,47 @@
+# Troubleshooting
+
+This is a collection of tips and common problems that might occur when trying to use an eGPU on the Linux Desktop. This document is not supposed to be a step-by-step guide on how to setup an eGPU, but rather provide some TL;DR assistance if you are running into problems.
+
+Please feel free to provide your own solutions to problems you might have had by issuing a Pull Request to this repository.
+
+## Common Problems
+For general problems with your graphics card or graphics drivers, please do a web search first. Consider reading the corresponding articles in the ArchWiki (eg. [NVIDIA/Troubleshooting - ArchWiki](https://wiki.archlinux.org/index.php/NVIDIA/Troubleshooting)) in order to find a solution to your problem.
+
+- **My eGPU is not recognized on `egpu-switcher setup` / `egpu-switcher config`**
+  
+  Please check for the usual errors first, maybe by trying the eGPU unit with a different device or operating system:
+  - Does the GPU work?
+  - Does the power supply of your eGPU case work?
+  - Does your TB3 cable work?
+  - Does your USB-C Port support TB3?
+
+  If you can exclude the issues mentioned above, check for the following:
+  - Does your system meet the [requirements](https://github.com/hertg/egpu-switcher#requirements)?
+  - Is Thunderbolt enabled in your BIOS?\
+  Also check whether you've set `Thunderbolt Security` to `USB-DP only` by accident.
+  - Did you authorize your eGPU? (see [boltctl](https://www.mankier.com/1/boltctl))
+  - Check if your eGPU shows up when running `lspci`. The egpu-switcher script is running this command internally to detect GPUs. If `lspci` doesn't find your GPU, neither will egpu-switcher.
+
+- **eGPU is not selected automatically on bootup**
+  - Make sure the GPU is connected **before** you start your computer.
+  - Check if egpu-switcher even detects your eGPU at runtime by executing `egpu-switcher switch auto` with the eGPU connected. If it doesn't recognize the eGPU please see the troubleshooting tips above.
+  - Try to re-run the `egpu-switcher config` and `egpu-switcher setup` command to reconfigure egpu-switcher.
+  - Check whether the `egpu.service` is still enabled in systemd and check its output in `journalctl`.
+  - In case there is a race-condition happening between `bolt` and `egpu-switcher`, try enabling `Pre-Boot ACL` in the BIOS and re-authorize your eGPU. With this setting enabled, your eGPU gets connected much faster. Be aware that this setting only makes sense with the Thunderbolt Security set to `user`  (see [#50](https://github.com/hertg/egpu-switcher/issues/50)).
+  - Try changing your Thunderbolt Security Level and see if it changes anything (I personally use Thunderbolt Security Level `user` and `Pre-Boot ACL` enabled).
+
+
+## Tips
+Below you'll find a none exhaustive list of some general tips that may prevent you from running into certain problems. The list is based on personal experience and not necessarily on best-practices, please take into consideration that it might be outdated, depending on the time you read it.
+
+- **Drivers**\
+If you happen to have an NVIDIA GPU, it's preferrable to use the proprietary NVIDIA graphics drivers rather than Nouveau (see [NVIDIA - ArchWiki](https://wiki.archlinux.org/index.php/NVIDIA)).
+
+- **Thunderbolt**\
+There have been less issues reported when `Pre-Boot ACL` was enabled in the BIOS. Enabling `Pre-Boot ACL` allows authorized Thunderbolt devices to connect during pre-boot and leads to the eGPU connecting much faster on bootup, therefore limiting the impact of race-conditions between `egpu-switcher` and `bolt`. Please be aware that this only makes sense with Thunderbolt Security set to `user`.
+
+- **Don't choose an explicit internal GPU**\
+Although `egpu-switcher config` will ask you whether you want to specify a specific internal GPU, it's not recommended to do so. Many users have reported that specifying the internal GPU explicitly will cause problems in certain situations, especially with the intel drivers (see [#33](https://github.com/hertg/egpu-switcher/issues/33)).
+
+- **Display Settings (BIOS)**\
+If you are using a laptop with hybrid graphics (dedicated GPU + internal graphics) try changing the `Display Settings` in your BIOS if a problem occurs and see if it changes anything. I've personally experienced system freezes in distro installers (I think it was Ubuntu 19.04) that could only be solved by changing `Display Settings` from `Hybrid Graphics` to `Discrete Graphics` before starting the installation. After the installation went successful, the display settings could be changed back to `Hybrid Graphics` without any issues.

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -144,15 +144,33 @@ function is_egpu_connected() {
 	declare bus2h=$(printf "%02x" $bus2d)
 	declare bus3h=$(printf "%01x" $bus3d)
 
-	if [ $( (lspci -d ::0300 && lspci -d ::0302) | grep -iEc "$bus1h:$bus2h.$bus3h") -eq 1 ]; then
-		print_info "EGPU is ${green}connected${blank}."
-		gpu_connected=1
-		hex_id=$bus1h:$bus2h.$bus3h
-		#return 1
-	else
-		print_info "EGPU is ${red}disconnected${blank}."
-		gpu_connected=0
-	fi
+	# instantiate counter
+	declare i=1
+
+	# begin infinite loop to allow retries if the egpu isn't connected immediately on bootup
+	while [ true ]; do
+
+		# if a video device is connected to the BUS-ID
+		if [ $( (lspci -d ::0300 && lspci -d ::0302) | grep -iEc "$bus1h:$bus2h.$bus3h") -eq 1 ]; then
+			print_info "EGPU is ${green}connected${blank}."
+			gpu_connected=1
+			hex_id=$bus1h:$bus2h.$bus3h
+			break
+		else
+			# escape the infinite loop after a certain amount of retries
+			if [ $i -ge 6 ]; then
+				print_info "EGPU is ${red}disconnected${blank}."
+				gpu_connected=0
+				break
+			fi
+		fi
+
+		# increase counter by 1
+		i=$(( $i + 1 ))
+
+		# sleep for 500ms before retrying
+		sleep 0.5
+	done
 }
 
 # get the matching driver according to the gpu name


### PR DESCRIPTION
This PR limits race conditions between `egpu-switcher` and `bolt` by re-introducing an artificial delay in the `is_egpu_connected()` method. The delay has been rewritten to re-try a certain amount of times, if the eGPU couldn't be detected immediately, in order to prevent an unnecessary delay after the eGPU has been found.

Additionally a `TROUBLESHOOTING.md` file has been added, summarizing some of the problems users might run into when using the script.