### PR TITLE
Add hex-id output to prevent error

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -161,6 +161,7 @@ function is_egpu_connected() {
 			if [ $i -ge 6 ]; then
 				print_info "EGPU is ${red}disconnected${blank}."
 				gpu_connected=0
+				hex_id=$bus1h:$bus2h.$bus3h
 				break
 			fi
 		fi


### PR DESCRIPTION
This PR adds hex-id variable assignment to is_egpu_connected() function even when egpu is not connected.

Previously when manually calling:

`# egpu-switcher switch egpu`

resulted in:

```
[info] EGPU is disconnected.
/usr/bin/egpu-switcher: line 377: hex_id: unbound variable
```

When setup to use an AMD gpu.
After this change, the script finishes normally.
I think this was the result of one of my PR changes so sorry about that.