### PR TITLE
Makefile: Allow reinstalling without interactive prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,18 @@ all:
 install:
 	mkdir -p ${DESTDIR}${BINDIR}
 	cp egpu-switcher ${DESTDIR}${BINDIR}/
-	
+
 	mkdir -p ${DESTDIR}${SHAREDIR}/egpu-switcher
 	cp xorg.conf.template ${DESTDIR}${SHAREDIR}/egpu-switcher/
 	cp egpu.service ${DESTDIR}${SHAREDIR}/egpu-switcher/
-	
+
 	mkdir -p ${DESTDIR}${MANDIR}
 	cp docs/egpu-switcher.1 ${DESTDIR}${MANDIR}/
+	rm -f ${DESTDIR}${MANDIR}/egpu-switcher.1.gz
 	gzip ${DESTDIR}${MANDIR}/egpu-switcher.1
 
 uninstall:
 	rm -f ${DESTDIR}${BINDIR}/egpu-switcher
 	rm -rfd ${DESTDIR}${SHAREDIR}/egpu-switcher
 	rm -f ${DESTDIR}${MANDIR}/egpu-switcher.1*
-	
+


### PR DESCRIPTION
This allows one to re-run `make install` without any interaction from the user.