### PR TITLE
fix broken if condition with modified xorg.conf

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -369,7 +369,7 @@ function switch() {
 		fi
 	fi
 
-	if [ ${mode} = "egpu" ] && [ $(cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \") != "nvidia" ]; then
+	if [ ${mode} = "egpu" ] && cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \" | grep -Fxq "nvidia"; then
 
 		if [ -z ${hex_id+x} ]; then
 			is_egpu_connected

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -369,7 +369,7 @@ function switch() {
 		fi
 	fi
 
-	if [ ${mode} = "egpu" ] && cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \" | grep -Fxq "nvidia"; then
+	if [ ${mode} = "egpu" ] && ! cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \" | grep -Fxq "nvidia"; then
 
 		if [ -z ${hex_id+x} ]; then
 			is_egpu_connected

--- a/egpu-switcher
+++ b/egpu-switcher
@@ -369,7 +369,8 @@ function switch() {
 		fi
 	fi
 
-	if [ ${mode} = "egpu" ] && ! cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \" | grep -Fxq "nvidia"; then
+	# when mode is 'egpu' and no 'nvidia' driver is used
+	if [ ${mode} = "egpu" ] && ! grep -Eiq 'Driver.*nvidia' $xfile_egpu; then
 
 		if [ -z ${hex_id+x} ]; then
 			is_egpu_connected


### PR DESCRIPTION
Fixes issue #56 - found a way to use grep to check for "if the output contains this specific word", which I think was the original intent of that functionality. Chaining `cat | grep | cut | grep` does seem a bit complex, I'm not sure if there's a simpler way to achieve this - but it should fix the problem, anyway.