### PR TITLE
fix #69

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -107,18 +107,20 @@ function read_gpus() {
 		declare bus=$(echo $line | grep -o -e "^[^ ]*")
 
 		# The bus IDs in hex
+    declare domainh=${bus:0:4}
 		declare bus1h=${bus:5:2}
 		declare bus2h=${bus:8:2}
 		declare bus3h=${bus:11:1}
 
 		# The bus IDs in dec
+    declare domaind=$((16#$domainh))
 		declare bus1d=$((16#$bus1h))
 		declare bus2d=$((16#$bus2h))
 		declare bus3d=$((16#$bus3h))
 
 		# Remove the whitespace at the beginning of the name
 		# And concatenate bus IDs
-		bus="${bus1d}:${bus2d}:${bus3d}"
+		bus="PCI:${bus1d}@${domaind}:${bus2d}:${bus3d}"
 		name=${name:1}
 
 		# Put the result into the gpus array
@@ -131,15 +133,23 @@ function read_gpus() {
 function is_egpu_connected() {
 
 	# read pci id from xorg.conf.egpu
-	declare egpu_pci_id=$(cat $xfile_egpu | grep -Ei "BusID" | grep -oEi '[0-9]+\:[0-9]+\:[0-9]+')
+	declare egpu_pci_id=$(cat $xfile_egpu | grep -Ei "BusID" | grep -oEi 'PCI:[0-9]+@[0-9]+:[0-9]+:[0-9]+')
 
-	# create an array by splitting the BUS-ID on ':'
-	declare busArray=(${egpu_pci_id//:/ })
+  # remove preceding "PCI:"
+  declare pci_removed=${egpu_pci_id:4}
+
+  # split string at "@" and ":"
+  declare busArray=(${pci_removed//@/ })
+  busArray=(${busArray[0]} ${busArray[1]//:/ })
+
+  # assign variables for individual parts of pci id
+  declare domaind=${busArray[1]}
 	declare bus1d=${busArray[0]}
-	declare bus2d=${busArray[1]}
-	declare bus3d=${busArray[2]}
+	declare bus2d=${busArray[2]}
+	declare bus3d=${busArray[3]}
 
 	# convert dec to hex
+  declare domainh=$(printf "%04x" $domaind)
 	declare bus1h=$(printf "%02x" $bus1d)
 	declare bus2h=$(printf "%02x" $bus2d)
 	declare bus3h=$(printf "%01x" $bus3d)
@@ -151,17 +161,17 @@ function is_egpu_connected() {
 	while [ true ]; do
 
 		# if a video device is connected to the BUS-ID
-		if [ $( (lspci -d ::0300 && lspci -d ::0302) | grep -iEc "$bus1h:$bus2h.$bus3h") -eq 1 ]; then
+		if [ $( (lspci -D -d ::0300 && lspci -D -d ::0302) | grep -iEc "$domainh:$bus1h:$bus2h.$bus3h") -eq 1 ]; then
 			print_info "EGPU is ${green}connected${blank}."
 			gpu_connected=1
-			hex_id=$bus1h:$bus2h.$bus3h
+			hex_id=$domainh:$bus1h:$bus2h.$bus3h
 			break
 		else
 			# escape the infinite loop after a certain amount of retries
 			if [ $i -ge 6 ]; then
 				print_info "EGPU is ${red}disconnected${blank}."
 				gpu_connected=0
-				hex_id=$bus1h:$bus2h.$bus3h
+				hex_id=$domainh:$bus1h:$bus2h.$bus3h
 				break
 			fi
 		fi
@@ -376,7 +386,7 @@ function switch() {
 			is_egpu_connected
 		fi
 		
-		declare disp_path=/sys/bus/pci/devices/[0-9a-f:]*${hex_id}/drm/card[0-9]*/card[0-9]*-*/status
+		declare disp_path=/sys/bus/pci/devices/${hex_id}/drm/card[0-9]*/card[0-9]*-*/status
 		declare disp_num=0
 		declare disp_disconnect=0
 		for disp in ${disp_path}; do
@@ -427,7 +437,7 @@ function remove() {
 
 	# Find GPU and audio devices
 	declare device_id=$(echo ${hex_id} | cut -f 1 -d '.').
-	declare device_path=/sys/bus/pci/devices/[0-9a-f:]*${device_id}[0-9]*/remove
+	declare device_path=/sys/bus/pci/devices/${device_id}[0-9]*/remove
 	declare vga_driver=$(cat $xfile_egpu | grep -Ei "Driver" | cut -f 2 -d \")
 
 	# Do actual GPU removal


### PR DESCRIPTION
- extend any interaction with BusID by the domain number so the full form of xorg.conf BusID is used
- remove some unneeded regex as the BusID is now present in full form